### PR TITLE
Fix #3: Add unicode support for emoji in task titles

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -18,9 +18,7 @@ export function validateTask(task: Task): void {
   }
 
   // Basic emoji/unicode validation
-  // Bug: This regex doesn't properly support all emoji
-  // Issue #3 will track fixing this
-  const basicAlphanumeric = /^[a-zA-Z0-9\s\-_.,!?]+$/;
+  const basicAlphanumeric = /^[\p{L}\p{N}\p{P}\p{Z}\p{Emoji}]+$/u;
   if (!basicAlphanumeric.test(task.title)) {
     throw new ValidationError('Task title contains invalid characters');
   }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -18,8 +18,8 @@ export function validateTask(task: Task): void {
   }
 
   // Basic emoji/unicode validation
-  const basicAlphanumeric = /^[\p{L}\p{N}\p{P}\p{Z}\p{Emoji}]+$/u;
-  if (!basicAlphanumeric.test(task.title)) {
+  const validTitle = /^[\p{L}\p{N}\p{P}\p{Z}\p{Emoji}]+$/u;
+  if (!validTitle.test(task.title)) {
     throw new ValidationError('Task title contains invalid characters');
   }
 


### PR DESCRIPTION
## Summary
This PR fixes Issue #3 by updating the validation regex to support emoji and unicode characters in task titles.

## Changes
- Updated `src/validation.ts` regex pattern
- Changed from `basicAlphanumeric` to `validTitle` with unicode support
- Tasks can now include emoji: 🚀 🐛 ✨ 📝

## Testing
- [x] Tested with various emoji
- [x] Tested with standard text
- [x] Validated length limits still work

## Examples
```typescript
// Now works!
createTask({
  title: "🚀 Deploy to production",
  // ...
});
```

## Breaking Changes
None

## Related Issues
Closes #3

⚠️ **Note:** This change may have security implications (see Issue #10)